### PR TITLE
No reason this wouldn't work on later versions of node. I cannot install...

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,7 +12,7 @@
   },
   "main": "index.js",
   "engines": {
-    "node": "~0.4.7"
+    "node": ">=0.4.7"
   },
   "dependencies": {
     "request": "2.1",


### PR DESCRIPTION
... via npm on node 0.6.6 right now.
