### PR TITLE
Add an options argument to query

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,7 +17,7 @@ Client.prototype.query = function(input, options, cb) {
   
   var query = '';
   for(var i in options) {
-    query += '&' + i + '=' + options[i];
+    query += '&' + i + '=' + encodeURIComponent(options[i]);
   }
   
   var uri = 'http://api.wolframalpha.com/v2/query?input=' + encodeURIComponent(input) + query + '&appid=' + this.appKey


### PR DESCRIPTION
The pull request adds a news argument to query, so you can specify options instead of the default `primary=true`. Options are formatted as an object, like this : `{option: value, option: value}`.
This new argument is optional, if not defined it will default to `{primary: true}`.
