### PR TITLE
Update libxmljs dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "request": "2.1",
-    "libxmljs": "0.8.1"
+    "libxmljs": "^0.13.0"
   },
   "devDependencies": {
     "tap": "~> 0.4.0"


### PR DESCRIPTION
This is necessary as of node 0.12.

I didn't get a chance to run the built in tests on my system, but so far my use of the package hasn't raised any errors.