### PR TITLE
Update libxmljs to 0.14.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "request": "2.1",
-    "libxmljs": "^0.13.0"
+    "libxmljs": "^0.14.0"
   },
   "devDependencies": {
     "tap": "~> 0.4.0"


### PR DESCRIPTION
0.13.0 causes build failures. 0.14.0 doesn't.